### PR TITLE
Due to changes to footwork in 2015, and counterstance in 2014, these …

### DIFF
--- a/scripts/globals/abilities/footwork.lua
+++ b/scripts/globals/abilities/footwork.lua
@@ -22,5 +22,5 @@ end;
 -----------------------------------
 
 function onUseAbility(player,target,ability)
-   player:addStatusEffect(EFFECT_FOOTWORK,1,0,300);
+   player:addStatusEffect(EFFECT_FOOTWORK,1,0,60);
 end;

--- a/scripts/globals/effects/footwork.lua
+++ b/scripts/globals/effects/footwork.lua
@@ -11,8 +11,7 @@ require("scripts/globals/status");
 -----------------------------------
 
 function onEffectGain(target,effect)
-    target:addMod(MOD_KICK_DMG,21);
-    target:addMod(MOD_ATTP,10);
+    target:addMod(MOD_KICK_ATTACK,20);
 end;
 
 -----------------------------------
@@ -27,6 +26,5 @@ end;
 -----------------------------------
 
 function onEffectLose(target,effect)
-    target:delMod(MOD_KICK_DMG,21);
-    target:delMod(MOD_ATTP,10);
+    target:delMod(MOD_KICK_ATTACK,20);
 end;

--- a/src/map/attack.cpp
+++ b/src/map/attack.cpp
@@ -209,12 +209,6 @@ uint8 CAttack::GetWeaponSlot()
 ************************************************************************/
 uint8 CAttack::GetAnimationID()
 {
-    // Footwork
-    if (m_attacker->GetMJob() == JOB_MNK && m_attacker->StatusEffectContainer->HasStatusEffect(EFFECT_FOOTWORK))
-    {
-        return this->m_attackDirection == RIGHTATTACK ? 2 : 3;
-    }
-
     // Try normal kick attacks (without footwork)
     if (this->m_attackType == PHYSICAL_ATTACK_TYPE::KICK)
     {

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -226,10 +226,7 @@ int16 CBattleEntity::GetWeaponDelay(bool tp)
     uint16 WeaponDelay = m_Weapons[SLOT_MAIN]->getDelay() - getMod(MOD_DELAY);
     if (m_Weapons[SLOT_MAIN]->getSkillType() == SKILL_H2H)
     {
-        if (!StatusEffectContainer->HasStatusEffect(EFFECT_FOOTWORK))
-        {
-            WeaponDelay -= getMod(MOD_MARTIAL_ARTS) * 1000 / 60;
-        }
+        WeaponDelay -= getMod(MOD_MARTIAL_ARTS) * 1000 / 60;
     }
     else if (m_Weapons[SLOT_SUB]->getDmgType() > 0 &&
              m_Weapons[SLOT_SUB]->getDmgType() < 4)
@@ -661,10 +658,10 @@ uint16 CBattleEntity::ACC(uint8 attackNumber, uint8 offsetAccuracy)
 
 uint16 CBattleEntity::DEF()
 {
-    if (this->StatusEffectContainer->HasStatusEffect(EFFECT_COUNTERSTANCE, 0)) {
-        return VIT() / 2 + 1;
-    }
     int32 DEF = 8 + m_modStat[MOD_DEF] + VIT() / 2;
+    if (this->StatusEffectContainer->HasStatusEffect(EFFECT_COUNTERSTANCE, 0)) {
+	return DEF / 2;
+    }
 
     return DEF + (DEF * m_modStat[MOD_DEFP] / 100) +
         dsp_min((DEF * m_modStat[MOD_FOOD_DEFP] / 100), m_modStat[MOD_FOOD_DEF_CAP]);


### PR DESCRIPTION
…have been altered.  Footwork no longer converts all attacks to kick attacks, it simply adds 20% to kick attack chance.  DMG and atk buff have been removed, and this commit uses MOD_KICK_ATTACK to increase the chance to kick by 20%.  For counterstance, the formula was changed from only using the VIT/2 to just halving current defense.  It's not clear to me if this is before or after food and buff modifiers, so I put it before.
